### PR TITLE
Fix homebrew not installing packages on first run

### DIFF
--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -31,16 +31,15 @@ Puppet::Type.type(:package).provide(:brewcask,
 
   def self.package_list(options={})
     begin
+      result = execute([command(:brew), :cask, :list, '--versions'])
+      result = "" if result.include?("Warning: nothing to list")
       if name = options[:justme]
         # Of course brew-cask has a different --versions format than brew when
         # getting the version of a single package
-        result = execute([command(:brew), :cask, :list, '--versions'])
         unless result.empty?
           result = Hash[result.lines.map {|line| line.split}]
           result = result[name] ? name + ' ' + result[name] : ''
         end
-      else
-        result = execute([command(:brew), :cask, :list, '--versions'])
       end
       list = result.lines.map {|line| name_version_split(line)}
     rescue Puppet::ExecutionFailure => detail

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,7 +33,7 @@ class homebrew::install {
 
   exec { 'install-homebrew':
     cwd       => '/usr/local',
-    command   => "/usr/bin/su ${homebrew::user} -c '/bin/bash -o pipefail -c \"/usr/bin/curl -skSfL https://github.com/mxcl/homebrew/tarball/master | /usr/bin/tar xz -m --strip 1\"'",
+    command   => "/usr/bin/su ${homebrew::user} -c '/bin/bash -o pipefail -c \"/usr/bin/curl -skSfL https://github.com/Homebrew/brew/tarball/master | /usr/bin/tar xz -m --strip 1\"'",
     creates   => '/usr/local/bin/brew',
     logoutput => on_failure,
     timeout   => 0,


### PR DESCRIPTION
Current Homebrew script fails to install packages when there's nothing already installed. Manual fix was to install one package manually and then re-run Puppet.
Cause was the return of the `brew cask --versions` command which is never empty since includes warnings and error messages that made the parser fail to work on them due it's string structure.
Added a easy fix to check whether the warming exist, if it does, the return value is set to empty. Tested on brand new MacOSX install running El Capitan.